### PR TITLE
Check if lines is defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,23 +26,25 @@ var unpackage = function (projects) {
         var methodStats = [],
             lineStats = [];
 
-        c.lines.forEach(function (l) {
-            if (l.$.type === "method") {
-                methodStats.push({
-                    name: l.$.name,
-                    line: Number(l.$.num),
-                    hit: Number(l.$.count)
-                });
-            }
-        });
-        c.lines.forEach(function (l) {
-            if (l.$.type !== "method") {
-                lineStats.push({
-                    line: Number(l.$.num),
-                    hit: Number(l.$.count)
-                });
-            }
-        });
+        if(c.lines !== undefined) {
+            c.lines.forEach(function (l) {
+                if (l.$.type === "method") {
+                    methodStats.push({
+                        name: l.$.name,
+                        line: Number(l.$.num),
+                        hit: Number(l.$.count)
+                    });
+                }
+            });
+            c.lines.forEach(function (l) {
+                if (l.$.type !== "method") {
+                    lineStats.push({
+                        line: Number(l.$.num),
+                        hit: Number(l.$.count)
+                    });
+                }
+            });
+        }
 
         var classCov = {
             title: c.name,

--- a/test/assets/clover-empty.xml
+++ b/test/assets/clover-empty.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1320170507">
+    <project timestamp="1320170507">
+        <package name="hello.world">
+            <file name="/app/Models/Scenario.php">
+            <class name="App\Models\Scenario" namespace="App\Models">
+                <metrics complexity="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+            </class>
+            <metrics loc="10" ncloc="10" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+            </file>
+            <metrics files="1" loc="0" ncloc="0" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+        </package>
+    </project>
+</coverage>

--- a/test/index.js
+++ b/test/index.js
@@ -46,4 +46,22 @@ describe("Check if it can parse a clover file", function () {
 
     });
 
+    it("should parse a file with an empty class", function (done) {
+
+        var filePath = path.join(__dirname, "assets", "clover-empty.xml");
+
+        parse.parseFile(filePath).then(function (result) {
+            assert.equal(result.length, 1);
+            assert.equal(result[0].functions.found, 0);
+            assert.equal(result[0].functions.hit, 0);
+            assert.equal(result[0].lines.found, 0);
+            assert.equal(result[0].lines.hit, 0);
+            done();
+        }).catch(function (err) {
+            assert.equal(err, null);
+            done();
+        });
+
+    });
+
 });


### PR DESCRIPTION
The code fails when there is a class without any lines, because `lines` is `undefined` in that case. For example, this fails to parse:

```xml
<file name="/app/Models/Scenario.php">
  <class name="App\Models\Scenario" namespace="App\Models">
    <metrics complexity="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
  </class>
  <metrics loc="10" ncloc="10" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
</file>
```

I fixed it so that the code only loops over lines when there are lines to loop over.