### PR TITLE
Add path to parsed coverage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,10 @@ var classDetailsFromProjects = function (projects) {
     var parseFile = function (fileObj, packageName) {
         if (fileObj.hasOwnProperty("class")) {
             fileObj["class"].forEach(function(classObj) {
-                classDetails = classDetails.concat({ name: classObj.$.name, metrics: classObj.metrics[0], fileName: fileObj.$.name, fileMetrics: fileObj.metrics[0], lines: fileObj.line, packageName: packageName });
+                classDetails = classDetails.concat({ name: classObj.$.name, metrics: classObj.metrics[0], fileName: fileObj.$.name, path: fileObj.$.path, fileMetrics: fileObj.metrics[0], lines: fileObj.line, packageName: packageName });
             });
         } else {
-            classDetails = classDetails.concat({ name: null, metrics: null, fileName: fileObj.$.name, fileMetrics: fileObj.metrics[0], lines: fileObj.line, packageName: packageName });
+            classDetails = classDetails.concat({ name: null, metrics: null, fileName: fileObj.$.name, path: fileObj.$.path, fileMetrics: fileObj.metrics[0], lines: fileObj.line, packageName: packageName });
         }
     }
 
@@ -68,6 +68,7 @@ var unpackage = function (projects) {
         var classCov = {
             title: c.name,
             file: c.fileName,
+            path: c.path,
             functions: {
                 found: methodStats.length,
                 hit: 0,

--- a/test/assets/clover1.xml
+++ b/test/assets/clover1.xml
@@ -2,7 +2,7 @@
 <coverage generated="1486026064">
     <project timestamp="1486026064">
         <package name="coveralls">
-            <file name="lib/client.js">
+            <file name="client.js" path="lib/client.js">
                 <class name="Client" namespace="coveralls">
                     <metrics complexity="41" methods="11" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="42" coveredstatements="23" elements="53" coveredelements="27"/>
                 </class>
@@ -13,7 +13,7 @@
                 <line num="9" type="stmt" count="2"/>
                 <metrics loc="202" ncloc="127" classes="1" methods="11" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="57" coveredstatements="38" elements="68" coveredelements="42"/>
             </file>
-            <file name="lib/configuration.js">
+            <file name="configuration.js" path="lib/configuration.js">
                 <class name="Configuration" namespace="coveralls">
                     <metrics complexity="59" methods="15" coveredmethods="13" conditionals="0" coveredconditionals="0" statements="55" coveredstatements="51" elements="70" coveredelements="64"/>
                 </class>
@@ -29,7 +29,7 @@
                 <line num="15" type="stmt" count="4"/>
                 <metrics loc="212" ncloc="132" classes="1" methods="15" coveredmethods="13" conditionals="0" coveredconditionals="0" statements="68" coveredstatements="64" elements="83" coveredelements="77"/>
             </file>
-            <file name="lib/git_commit.js">
+            <file name="git_commit.js" path="lib/git_commit.js">
                 <class name="GitCommit" namespace="coveralls">
                     <metrics complexity="35" methods="16" coveredmethods="15" conditionals="0" coveredconditionals="0" statements="40" coveredstatements="38" elements="56" coveredelements="53"/>
                 </class>

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,7 @@ describe("Check if it can parse a clover file", function () {
             assert.equal(result[0].functions.details[0].hit, 2);
             assert.equal(result[0].lines.details[0].line, 6);
             assert.equal(result[0].lines.details[0].hit, 2);
+            assert.equal(result[0].path, "lib/client.js");
             done();
         }).catch(function (err) {
             console.log(err)


### PR DESCRIPTION
Depending on how they're output, Clover files sometimes include only the base filename in the `name` attribute, with the full path in the `path` attribute. I've noticed this with the coverage emitted by [vitest](https://vitest.dev/guide/coverage) for instance. This PR adds an element for `path` so that both file name and path can be accessed.